### PR TITLE
Update published config file

### DIFF
--- a/config/mailchimp.php
+++ b/config/mailchimp.php
@@ -17,7 +17,6 @@ return [
         */
         'audience_id' => null,
 
-
         /*
         * Mailchimp Tag to assign to the contact.
         *

--- a/config/mailchimp.php
+++ b/config/mailchimp.php
@@ -17,6 +17,21 @@ return [
         */
         'audience_id' => null,
 
+
+        /*
+        * Mailchimp Tag to assign to the contact.
+        *
+        * @see https://mailchimp.com/help/getting-started-tags/
+        */
+        'tag' => null,
+
+        /*
+        * Use this field in your user to indicate which Mailchimp Tag to use
+        *
+        * @see https://mailchimp.com/help/getting-started-tags/
+        */
+        'tag_field' => null,
+
         /*
         * This is NOT recommended and means that they WILL NOT get the opt in email.
         * NOTE: This may violate privacy laws and may get your banned from Mailchimp
@@ -40,7 +55,7 @@ return [
         'merge_fields' => [
             [
                 /*
-                * The Mailchimp tag
+                * The Mailchimp merge field
                 */
                 'tag'=> null,
 
@@ -51,11 +66,6 @@ return [
             ],
         ],
 
-        /*
-        * To have single opt in only, which I don't recommend, set this to `true`.
-        * See: https://mailchimp.com/help/single-opt-in-vs-double-opt-in/ for details
-        */
-        'disable_opt_in' => false,
     ],
 
     /*
@@ -64,10 +74,40 @@ return [
     'forms' => [
         [
             /*
+            * handle of the form to listen for
+            */
+            'form' => null,
+
+            /*
+            * Define the handle for the email field to be used. Defaults to 'email'.
+            */
+            'primary_email_field' => 'email',
+
+            /*
+            * if you'd like to add "interests" in a group, which field is collecting those ids? Defaults to 'interests'
+            */
+            'interests_field' => 'interests',
+
+            /*
             * A MailChimp audience id. Check the MailChimp docs if you don't know
             * how to get this value: https://mailchimp.com/help/find-audience-id/.
             */
             'audience_id' => null,
+
+            /*
+            * Mailchimp Tag to assign to the contact.
+            * NOTE: `tag_field` takes precendence over `tag`
+            *
+            * @see https://mailchimp.com/help/getting-started-tags/
+            */
+            'tag' => null,
+
+            /*
+            * Use this field in your user to indicate which Mailchimp Tag to use
+            *
+            * @see https://mailchimp.com/help/getting-started-tags/
+            */
+            'tag_field' => null,
 
             /*
             * This is NOT recommended and means that they WILL NOT get the opt in email.
@@ -92,16 +132,6 @@ return [
             'disable_opt_in' => false,
 
             /*
-            * handle of the form to listen for
-            */
-            'form' => null,
-
-            /*
-            * if you'd like to add "interests" in a group, which field is collecting those ids? Defaults to 'interests'
-            */
-            'interests_field' => 'interests',
-
-            /*
             * See https://mailchimp.com/help/manage-audience-signup-form-fields/ for details on
             * Mailchimp merge fields
             */
@@ -118,16 +148,6 @@ return [
                     'field_name' => null,
                 ],
             ],
-
-            /*
-            * Define the handle for the email field to be used. Defaults to 'email'.
-            */
-            'primary_email_field' => 'email',
-
-            /*
-            * if you'd like to apply a tag to each member when they submit a particular form
-            */
-            'tag' => 'Tag One',
         ],
     ],
 ];


### PR DESCRIPTION
After upgrading to the latest version of this package, I started getting an exception on register because I had `'add_new_users' => true,`.

This was the exception: 
```
TypeError: Silentz\Mailchimp\Subscriber::tag(): Return value must be of type string, null returned
```

It turned out that it was looking for the `tag` config inside the `mailchimp.users` config, but it wasn't there. I took what was documented in the README and placed it in the config file that gets published. 

Some upgrade instructions should probably be added to the release that indicates to force publish the config and update the values that were modified from the base install. 

```
php artisan vendor:publish --tag="mailchimp-config" --force
```